### PR TITLE
Run tests with libnetcdf nompi, mpich and openmpi variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,6 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       #if [[ $CIRCLE_BRANCH != "master" ]]; then
-       #   exit 0
-       #fi
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
@@ -425,4 +422,7 @@ workflows:
                  - linux_cdutil_mpich_py36
                  - linux_cdutil_mpich_py37
                  - linux_cdutil_mpich_py38
+              filters:
+                 branches:
+                    only: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ aliases:
     command: |
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       conda create -y -n $ENV_NAME --use-local $CHANNELS "$CONDA_PY_VER" $PKG_NAME $PKGS $COVERAGE_PKGS
+       echo "conda create -y -n $ENV_NAME --use-local $CHANNELS \"$CONDA_PY_VER\" $PKG_NAME $PKGS $COVERAGE_PKGS \"$LIBNETCDF\""
+       conda create -y -n $ENV_NAME --use-local $CHANNELS "$CONDA_PY_VER" $PKG_NAME $PKGS $COVERAGE_PKGS "$LIBNETCDF"
        conda activate $ENV_NAME
        conda list
 
@@ -69,7 +70,10 @@ aliases:
        conda deactivate
 
 jobs:
-   macos_setup:
+   #
+   # setup_miniconda, rerender and build -- 'cdutil' is noarch
+   #
+   macos_build:
       macos:
          xcode: "11.4.0"
       environment:
@@ -88,7 +92,7 @@ jobs:
               paths: 
                  - macos_build
 
-   linux_setup:
+   linux_build:
       machine:
          image: circleci/classic:latest
       environment:
@@ -107,15 +111,18 @@ jobs:
               paths:
                  - linux_build
 
-   macos_cdutil_py36:
+   #
+   # run tests with libnetcdf nompi
+   #
+   macos_cdutil_nompi_py36:
       macos:
          xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
@@ -126,15 +133,15 @@ jobs:
               path: tests_html
               destination: tests_html
 
-   macos_cdutil_py37:
+   macos_cdutil_nompi_py37:
       macos:
          xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
@@ -145,15 +152,15 @@ jobs:
               path: tests_html
               destination: tests_html
 
-   macos_cdutil_py38:
+   macos_cdutil_nompi_py38:
       macos:
          xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
@@ -164,15 +171,15 @@ jobs:
               path: tests_html
               destination: tests_html
 
-   linux_cdutil_py36:
+   linux_cdutil_nompi_py36:
       machine:
          image: circleci/classic:latest
       environment:
          WORKDIR: /home/circleci/project/linux_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
@@ -183,15 +190,15 @@ jobs:
               path: tests_html
               destination: tests_html
 
-   linux_cdutil_py37:
+   linux_cdutil_nompi_py37:
       machine:
          image: circleci/classic:latest
       environment:
          WORKDIR: /home/circleci/project/linux_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
          COVERAGE: "-c tests/coverage.json --coverage-from-egg"
          COVERAGE_PKGS: "coverage coveralls"
       steps:
@@ -205,15 +212,135 @@ jobs:
               path: tests_html
               destination: tests_html
 
-   linux_cdutil_py38:
+   linux_cdutil_nompi_py38:
       machine:
          image: circleci/classic:latest
       environment:
          WORKDIR: /home/circleci/project/linux_build
          PKG_NAME: "cdutil"
-         REPO_NAME: "cdutil"
          ENV_NAME: "test_cdutil"
          CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   #
+   # run tests with libnetcdf mpich
+   #
+   macos_cdutil_mpich_py36:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_cdutil_mpich_py37:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_cdutil_mpich_py38:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_cdutil_mpich_py36:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_cdutil_mpich_py37:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+         COVERAGE: "-c tests/coverage.json --coverage-from-egg"
+         COVERAGE_PKGS: "coverage coveralls"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - run: *run_coveralls
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_cdutil_mpich_py38:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build
+         PKG_NAME: "cdutil"
+         ENV_NAME: "test_cdutil"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
       steps:
          - checkout
          - attach_workspace:
@@ -243,31 +370,59 @@ workflows:
    version: 2
    cdutil:
       jobs:
-         - macos_setup
-         - linux_setup
-         - macos_cdutil_py36:
+         - macos_build
+         - linux_build
+         - macos_cdutil_nompi_py36:
               requires:
-                 - macos_setup
-         - macos_cdutil_py37:
+                 - macos_build
+         - macos_cdutil_nompi_py37:
               requires:
-                 - macos_setup
-         - macos_cdutil_py38:
+                 - macos_build
+         - macos_cdutil_nompi_py38:
               requires:
-                 - macos_setup
-         - linux_cdutil_py36:
+                 - macos_build
+         - linux_cdutil_nompi_py36:
               requires:
-                 - linux_setup
-         - linux_cdutil_py37:
+                 - linux_build
+         - linux_cdutil_nompi_py37:
               requires:
-                 - linux_setup
-         - linux_cdutil_py38:
+                 - linux_build
+         - linux_cdutil_nompi_py38:
               requires:
-                 - linux_setup
+                 - linux_build
+
+         - macos_cdutil_mpich_py36:
+              requires:
+                 - macos_build
+         - macos_cdutil_mpich_py37:
+              requires:
+                 - macos_build
+         - macos_cdutil_mpich_py38:
+              requires:
+                 - macos_build
+         - linux_cdutil_mpich_py36:
+              requires:
+                 - linux_build
+         - linux_cdutil_mpich_py37:
+              requires:
+                 - linux_build
+         - linux_cdutil_mpich_py38:
+              requires:
+                 - linux_build
+
          - upload:
               requires:
-                 - macos_cdutil_py36
-                 - macos_cdutil_py37
-                 - macos_cdutil_py38
-                 - linux_cdutil_py36
-                 - linux_cdutil_py37
-                 - linux_cdutil_py38
+                 - macos_cdutil_nompi_py36
+                 - macos_cdutil_nompi_py37
+                 - macos_cdutil_nompi_py38
+                 - linux_cdutil_nompi_py36
+                 - linux_cdutil_nompi_py37
+                 - linux_cdutil_nompi_py38
+
+                 - macos_cdutil_mpich_py36
+                 - macos_cdutil_mpich_py37
+                 - macos_cdutil_mpich_py38
+                 - linux_cdutil_mpich_py36
+                 - linux_cdutil_mpich_py37
+                 - linux_cdutil_mpich_py38
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,9 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != "master" ]]; then
-          exit 0
-       fi
+       #if [[ $CIRCLE_BRANCH != "master" ]]; then
+       #   exit 0
+       #fi
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"

--- a/cdutil/create_landsea_mask.py
+++ b/cdutil/create_landsea_mask.py
@@ -1,7 +1,6 @@
 import cdms2
 import MV2
 import os
-import cdat_info
 import pkg_resources
 
 egg_path = pkg_resources.resource_filename(pkg_resources.Requirement.parse("cdutil"), "share/cdutil")

--- a/cdutil/region.py
+++ b/cdutil/region.py
@@ -1,6 +1,5 @@
 # Adapted for numpy/ma/cdms2 by convertcdms.py
 from cdms2.selectors import SelectorComponent
-import cdat_info
 import warnings
 
 

--- a/cdutil/sftbyrgn.py
+++ b/cdutil/sftbyrgn.py
@@ -9,7 +9,6 @@ import MV2
 import genutil
 import cdms2
 import os
-import cdat_info
 import pkg_resources
 
 

--- a/cdutil/times.py
+++ b/cdutil/times.py
@@ -4,7 +4,6 @@ import MV2
 import cdms2
 import cdtime
 import numpy.ma
-import cdat_info
 
 try:
     basestring
@@ -320,7 +319,7 @@ def mergeTime(ds, statusbar=1, fill_value=1.e20):
                         raise Exception  # to exit the it and i loops
                     elif val.value > vals[v]:
                         break
-        except BaseException as err:
+        except BaseException:
             pass
     if statusbar is not None and nt != 1:
         if not isinstance(prev[0], type(0)):

--- a/cdutil/vertical.py
+++ b/cdutil/vertical.py
@@ -3,7 +3,6 @@ import MV2
 import genutil
 import cdms2
 import numpy
-import cdat_info
 
 
 def reconstructPressureFromHybrid(ps, A, B, Po):

--- a/recipe/meta.yaml.in
+++ b/recipe/meta.yaml.in
@@ -15,7 +15,6 @@ requirements:
   build:
     - python
     - setuptools
-    - cdat_info
   run:
     - python
     - cdms2

--- a/tests/test_cdutil_flake8.py
+++ b/tests/test_cdutil_flake8.py
@@ -11,7 +11,7 @@ class TestFlake8(unittest.TestCase):
         pth = os.path.dirname(__file__)
         pth = os.path.join(pth, "..")
         pth = os.path.abspath(pth)
-        pth = os.path.join(pth, "Lib")
+        pth = os.path.join(pth, "cdutil")
         print()
         print()
         print()


### PR DESCRIPTION
Updated circleci workflow to run tests with libnetcdf nompi, mpich and openmpi variants.
Fixed flake8 (3.8.1) failures.
Removed cdat_info from 'build' section of recipe/meta.yaml.in, cdat_info is not needed.
