### PR TITLE
cleanup, and set conda_build_env to a default if not passed in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,5 @@
 version: 2.1
 
-parameters:
-   pkg_name:
-      type: string
-      default: "cdutil"
-   repo_name:
-      type: string
-      default: "cdutil"
-   last_stable:
-      type: string
-      default: "8.2"
-   user:
-      type: string
-      default: "cdat"
-   label:
-      type: string
-      default: "nightly"
-   env_name:
-      type: string
-      default: "test_cdutil"
-
-
 aliases:
   - &setup_env
     name: setup_env
@@ -37,7 +16,6 @@ aliases:
     name: setup_miniconda
     command: |
        source $BASH_ENV
-       mkdir -p $WORKDIR
        git clone https://github.com/CDAT/cdat.git $WORKDIR/cdat
        # install_miniconda.py installs miniconda3 under $WORKDIR/miniconda
        python $WORKDIR/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
@@ -48,7 +26,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       make conda-rerender conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR last_stable=$LAST_STABLE branch=$CIRCLE_BRANCH
+       make conda-rerender workdir=$WORKDIR conda_build_env=base branch=$CIRCLE_BRANCH
 
   - &conda_build
     name: conda_build
@@ -58,7 +36,7 @@ aliases:
        conda activate base
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.noarch"
-       make conda-build conda=$WORKDIR/miniconda/bin/conda workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir
+       make conda-build workdir=$WORKDIR conda_build_env=base artifact_dir=$PWD/$artifacts_dir
 
   - &setup_run_tests
     name: setup_run_tests
@@ -68,8 +46,8 @@ aliases:
        conda activate base
        export CONDA_PY_VER="python=$PY_VER"
        export LIBNETCDF_VER="libnetcdf=*=${LIBNETCDF}_*"
-       make setup-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME extra_pkgs="$CONDA_PY_VER $LIBNETCDF_VER $COVERAGE_PKGS"
-       make conda-dump-env conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME artifact_dir=$PWD/spec_artifacts conda_env_filename=$CIRCLE_JOB
+       make setup-tests extra_pkgs="$CONDA_PY_VER $LIBNETCDF_VER $COVERAGE_PKGS"
+       make conda-dump-env workdir=$WORKDIR conda_env=$ENV_NAME artifact_dir=$PWD/spec_artifacts conda_env_filename=$CIRCLE_JOB
 
   - &run_tests
     name: run_tests
@@ -77,7 +55,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate $ENV_NAME
-       make run-tests conda=$WORKDIR/miniconda/bin/conda conda_env=$ENV_NAME
+       make run-tests workdir=$WORKDIR
 
   - &conda_upload
     name: conda_upload
@@ -85,8 +63,9 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN user=$USER label=$LABEL"
-       make conda-upload $UPLOAD_OPTIONS conda=$WORKDIR/miniconda/bin/conda artifact_dir="$PWD/artifacts/*Linux*/"
+       #UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN label=linatest"
+       make conda-upload $UPLOAD_OPTIONS artifact_dir="$PWD/artifacts/*Linux*/"
 
   - &run_coveralls
     name: run_coveralls
@@ -111,10 +90,6 @@ jobs:
          os:
             type: executor
       executor: << parameters.os >>
-      environment:
-         PKG_NAME: << pipeline.parameters.pkg_name >>
-         REPO_NAME: << pipeline.parameters.repo_name >>
-         LAST_STABLE: << pipeline.parameters.last_stable >>
       steps:
          - checkout
          - run: *setup_env
@@ -137,8 +112,6 @@ jobs:
             type: string
       executor: << parameters.os >>
       environment:
-         PKG_NAME: << pipeline.parameters.pkg_name >>
-         ENV_NAME: << pipeline.parameters.env_name >>
          PY_VER: << parameters.py_ver >>
          LIBNETCDF: << parameters.libnetcdf >>
       steps:
@@ -159,9 +132,6 @@ jobs:
    upload:
       machine:
          image: circleci/classic:latest
-      environment:
-         USER: << pipeline.parameters.user >>
-         LABEL: << pipeline.parameters.label >>
       steps:
          - checkout
          - attach_workspace:
@@ -190,7 +160,7 @@ workflows:
          - upload:
               requires:
                  - test
-              filters:
-                 branches:
-                    only: master
+#              filters:
+#                 branches:
+#                    only: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,15 +47,14 @@ aliases:
        export CONDA_PY_VER="python=$PY_VER"
        export LIBNETCDF_VER="libnetcdf=*=${LIBNETCDF}_*"
        make setup-tests extra_pkgs="$CONDA_PY_VER $LIBNETCDF_VER $COVERAGE_PKGS"
-       make conda-dump-env workdir=$WORKDIR conda_env=$ENV_NAME artifact_dir=$PWD/spec_artifacts conda_env_filename=$CIRCLE_JOB
+       make conda-dump-env artifact_dir=$PWD/spec_artifacts conda_env_filename=$CIRCLE_JOB
 
   - &run_tests
     name: run_tests
     command: |
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate $ENV_NAME
-       make run-tests workdir=$WORKDIR
+       make run-tests
 
   - &conda_upload
     name: conda_upload
@@ -71,9 +70,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate $ENV_NAME
-       coveralls
-       conda deactivate
+       conda activate base
+       make run-coveralls
 
 executors:
    linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       #UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN label=linatest"
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
        make conda-upload $UPLOAD_OPTIONS artifact_dir="$PWD/artifacts/*Linux*/"
 
   - &run_coveralls
@@ -160,7 +159,7 @@ workflows:
          - upload:
               requires:
                  - test
-#              filters:
-#                 branches:
-#                    only: master
+              filters:
+                 branches:
+                    only: master
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ build_script = conda-recipes/build_tools/conda_build.py
 test_pkgs = testsrunner coverage coveralls
 last_stable ?= 8.2
 
-conda_env ?= base
+conda_build_env ?= build-$(pkg_name)
+conda_test_env ?= test-$(pkg_name)
+
 workdir ?= $(PWD)/workspace
 branch ?= $(shell git rev-parse --abbrev-ref HEAD)
 extra_channels ?= cdat/label/nightly conda-forge
@@ -35,10 +37,10 @@ local_repo = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 endif
 
 conda-info:
-	source $(conda_activate) $(conda_env); conda info
+	source $(conda_activate) $(conda_test_env); conda info
 
 conda-list:
-	source $(conda_activate) $(conda_env); conda list
+	source $(conda_activate) $(conda_test_env); conda list
 
 setup-build:
 ifeq ($(wildcard $(workdir)/conda-recipes),)
@@ -48,33 +50,33 @@ else
 endif
 
 setup-tests:
-	source $(conda_activate) base; conda create -y -n $(conda_env) --use-local \
+	source $(conda_activate) base; conda create -y -n $(conda_test_env) --use-local \
 		$(foreach x,$(extra_channels),-c $(x)) $(pkg_name) $(foreach x,$(test_pkgs),"$(x)") \
 		$(foreach x,$(extra_pkgs),"$(x)")
 
 conda-rerender: setup-build 
 	python $(workdir)/$(build_script) -w $(workdir) -l $(last_stable) -B 0 -p $(pkg_name) \
-		-b $(branch) --do_rerender --conda_env $(conda_env) --ignore_conda_missmatch \
+		-b $(branch) --do_rerender --conda_env $(conda_build_env) --ignore_conda_missmatch \
 		--conda_activate $(conda_activate)
 
 conda-build:
 	mkdir -p $(artifact_dir)
 
 	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version noarch \
-		--do_build --conda_env $(conda_env) --extra_channels $(extra_channels) \
+		--do_build --conda_env $(conda_build_env) --extra_channels $(extra_channels) \
 		--conda_activate $(conda_activate) $(conda_build_extra)
 
 conda-upload:
-	source $(conda_activate) $(conda_env); \
+	source $(conda_activate) $(conda_build_env); \
 		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*.tar.bz2
 
 conda-dump-env:
 	mkdir -p $(artifact_dir)
 
-	source $(conda_activate) $(conda_env); conda list --explicit > $(artifact_dir)/$(conda_env_filename).txt
+	source $(conda_activate) $(conda_test_env); conda list --explicit > $(artifact_dir)/$(conda_env_filename).txt
 
 run-tests:
-	source $(conda_activate) $(conda_env); python run_tests.py -H -v2 $(coverage_opt)
+	source $(conda_activate) $(conda_test_env); python run_tests.py -H -v2 $(coverage_opt)
 
 run-coveralls:
-	source $(conda_activate) $(conda_env); coveralls;
+	source $(conda_activate) $(conda_test_env); coveralls;

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL = /bin/bash
 
 os = $(shell uname)
 pkg_name = cdutil
+
+user ?= cdat
+label ?= nightly
+
 build_script = conda-recipes/build_tools/conda_build.py
 
 test_pkgs = testsrunner coverage coveralls


### PR DESCRIPTION
+ clean up .circleci/config.yml
+ set conda_build_env and conda_test_env to a default value in Makefile if it is not passed in.
+ pass in 'conda_build_env=base' when doing 'make conda-rerender' and 'make conda-build' in .circleci/config.yml
